### PR TITLE
Fixed PullResult type for RPC stream queries

### DIFF
--- a/.changeset/gold-lions-leave.md
+++ b/.changeset/gold-lions-leave.md
@@ -1,0 +1,5 @@
+---
+"@effect-atom/atom": patch
+---
+
+Fixed PullResult type for RPC stream queries

--- a/docs/atom/AtomRpc.ts.md
+++ b/docs/atom/AtomRpc.ts.md
@@ -88,7 +88,10 @@ export interface AtomRpcClient<Rpcs extends Rpc.Any, E> {
     infer _Middleware
   >
     ? [_Success] extends [RpcSchema.Stream<infer _A, infer _E>]
-      ? Atom.Writable<Atom.PullResult<_A, _E | _Error["Type"] | E | _Middleware["failure"]["Type"]>, void>
+      ? Atom.Writable<
+          Atom.PullResult<_A["Type"], _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"]>,
+          void
+        >
       : Atom.Atom<Result.Result<_Success["Type"], _Error["Type"] | E | _Middleware["failure"]["Type"]>>
     : never
 }

--- a/packages/atom/src/AtomRpc.ts
+++ b/packages/atom/src/AtomRpc.ts
@@ -70,8 +70,8 @@ export interface AtomRpcClient<Rpcs extends Rpc.Any, E> {
     infer _Middleware
   > ? [_Success] extends [RpcSchema.Stream<infer _A, infer _E>] ? Atom.Writable<
         Atom.PullResult<
-          _A,
-          _E | _Error["Type"] | E | _Middleware["failure"]["Type"]
+          _A["Type"],
+          _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"]
         >,
         void
       >


### PR DESCRIPTION
Hello,

I was playing around with `AtomRpc` and I noticed an issue when querying an RPC stream. The result and error types are schema classes, not the actual types. For example:
```tsx
const countsResult: Atom.PullResult<typeof Schema.Number, Schema.Literal<["Test Error"]>>
```
<details>
<summary>Full Example Code</summary>

```tsx
import { FetchHttpClient } from '@effect/platform';
import { RpcGroup } from '@effect/rpc';
import * as Rpc from '@effect/rpc/Rpc';
import * as RpcClient from '@effect/rpc/RpcClient';
import * as RpcSerialization from '@effect/rpc/RpcSerialization';
import { Atom, AtomRpc, Result, useAtomValue } from '@effect-atom/atom-react';
import * as Layer from 'effect/Layer';
import * as Schema from 'effect/Schema';

class Rpcs extends RpcGroup.make(
  Rpc.make('count', {
    success: Schema.Number,
    error: Schema.Literal('Test Error'),
    stream: true,
  })
) {}

const rpcAtom = AtomRpc.make(Rpcs, {
  runtime: Atom.runtime(
    RpcClient.layerProtocolHttp({
      url: 'http://localhost:3000',
    }).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(RpcSerialization.layerJson))
  ),
});

function SomeComponent() {
  // This value has an incorrect type
  const countsResult = useAtomValue(rpcAtom.query('count', void 0, {}));
  const counts: number[] = Result.match(countsResult, {
    onFailure: () => [],
    onInitial: () => [],
    onSuccess: (res) => res.value.items,
  });

  return (
    <div>
      {counts.map((count) => (
        <p key={count}>{count}</p>
      ))}
    </div>
  );
}

```

</details>

I went ahead and fixed it by updating the return type of `AtomRpcClient.query` to return the actual deserialized type:
```tsx
const countsResult: Atom.PullResult<number, "Test Error">
```

This makes it match the behavior of non-streamed queries and the actual data.