### PR TITLE
Atom.fn: abort shows interruption failure

### DIFF
--- a/.changeset/tender-cougars-judge.md
+++ b/.changeset/tender-cougars-judge.md
@@ -1,0 +1,6 @@
+---
+"@effect-atom/atom-react": patch
+"@effect-atom/atom": patch
+---
+
+Add opt-in `abortAsFailure` to Atom.fn: when enabled, aborting (Reset) yields an interruption failure instead of Initial. In React, useAtom/useAtomSet support AbortSignal for Atom.fn in promise modes; aborting fails with interruption.

--- a/docs/atom-react/Hooks.ts.md
+++ b/docs/atom-react/Hooks.ts.md
@@ -34,23 +34,30 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const useAtom: <R, W, const Mode extends "value" | "promise" | "promiseExit" = never>(
-  atom: Atom.Writable<R, W>,
-  options?: { readonly mode?: ([R] extends [Result.Result<any, any>] ? Mode : "value") | undefined }
-) => readonly [
-  value: R,
-  write: "promise" extends Mode
-    ? (
-        value: W,
-        options?: { readonly signal?: AbortSignal | undefined } | undefined
-      ) => Promise<Result.Result.Success<R>>
-    : "promiseExit" extends Mode
-      ? (
-          value: W,
-          options?: { readonly signal?: AbortSignal | undefined } | undefined
-        ) => Promise<Exit.Exit<Result.Result.Success<R>, Result.Result.Failure<R>>>
-      : (value: W | ((value: R) => W)) => void
-]
+export declare const useAtom: {
+  <Arg, A, E, const Mode extends "value" | "promise" | "promiseExit" = never>(
+    atom: Atom.AtomResultFn<Arg, A, E>,
+    options?: { readonly mode?: Mode | undefined }
+  ): readonly [
+    value: Result.Result<A, E>,
+    write: "promise" extends Mode
+      ? (value: Arg, options?: { readonly signal?: AbortSignal | undefined } | undefined) => Promise<A>
+      : "promiseExit" extends Mode
+        ? (value: Arg, options?: { readonly signal?: AbortSignal | undefined } | undefined) => Promise<Exit.Exit<A, E>>
+        : (value: Arg | ((value: Result.Result<A, E>) => Arg)) => void
+  ]
+  <R, W, const Mode extends "value" | "promise" | "promiseExit" = never>(
+    atom: Atom.Writable<R, W>,
+    options?: { readonly mode?: ([R] extends [Result.Result<any, any>] ? Mode : "value") | undefined }
+  ): readonly [
+    value: R,
+    write: "promise" extends Mode
+      ? (value: W) => Promise<Result.Result.Success<R>>
+      : "promiseExit" extends Mode
+        ? (value: W) => Promise<Exit.Exit<Result.Result.Success<R>, Result.Result.Failure<R>>>
+        : (value: W | ((value: R) => W)) => void
+  ]
+}
 ```
 
 Added in v1.0.0
@@ -120,17 +127,24 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const useAtomSet: <R, W, Mode extends "value" | "promise" | "promiseExit" = never>(
-  atom: Atom.Writable<R, W>,
-  options?: { readonly mode?: ([R] extends [Result.Result<any, any>] ? Mode : "value") | undefined }
-) => "promise" extends Mode
-  ? (value: W, options?: { readonly signal?: AbortSignal | undefined } | undefined) => Promise<Result.Result.Success<R>>
-  : "promiseExit" extends Mode
-    ? (
-        value: W,
-        options?: { readonly signal?: AbortSignal | undefined } | undefined
-      ) => Promise<Exit.Exit<Result.Result.Success<R>, Result.Result.Failure<R>>>
-    : (value: W | ((value: R) => W)) => void
+export declare const useAtomSet: {
+  <Arg, A, E, Mode extends "value" | "promise" | "promiseExit" = never>(
+    atom: Atom.AtomResultFn<Arg, A, E>,
+    options?: { readonly mode?: Mode | undefined }
+  ): "promise" extends Mode
+    ? (value: Arg, options?: { readonly signal?: AbortSignal | undefined } | undefined) => Promise<A>
+    : "promiseExit" extends Mode
+      ? (value: Arg, options?: { readonly signal?: AbortSignal | undefined } | undefined) => Promise<Exit.Exit<A, E>>
+      : (value: Arg | ((value: Result.Result<A, E>) => Arg)) => void
+  <R, W, Mode extends "value" | "promise" | "promiseExit" = never>(
+    atom: Atom.Writable<R, W>,
+    options?: { readonly mode?: ([R] extends [Result.Result<any, any>] ? Mode : "value") | undefined }
+  ): "promise" extends Mode
+    ? (value: W) => Promise<Result.Result.Success<R>>
+    : "promiseExit" extends Mode
+      ? (value: W) => Promise<Exit.Exit<Result.Result.Success<R>, Result.Result.Failure<R>>>
+      : (value: W | ((value: R) => W)) => void
+}
 ```
 
 Added in v1.0.0


### PR DESCRIPTION
React useAtom/useAtomSet: AbortSignal for Atom.fn
promise modes; abort fails with interruption.
